### PR TITLE
Two more options: hideheader and detailview

### DIFF
--- a/database2.php
+++ b/database2.php
@@ -2858,10 +2858,11 @@ EOT;
 
 				$session['search'] = array();
 
-				if ( $this->options['basefilter'] )
+				if ( $this->options['basefilter'] ) {
 					// initialize filter using provided code
 					return ( $session['search'] = $this->parseFilterCode( $this->options['basefilter'] ) );
 
+				}
 
 
 			// parse filter input and transfer it to session

--- a/database2.php
+++ b/database2.php
@@ -2942,16 +2942,17 @@ EOT;
 
 				if ( $argument !== '' )
 					// 2) filter operates with non-empty argument
-					if ( $opMap[$filter['op']] )
+					$op = strtolower($filter['op']);
+					if ( $opMap[$op] )
 					{
 						// 3) filter uses valid operation
 						// ----> include it.
 
-						if ( in_array( $filter['op'], array( 'like', 'nlike' ) ) )
+						if ( in_array( $op, array( 'like', 'nlike' ) ) )
 							if ( strpos( $argument, '%' ) === false )
 								$argument = '%' . $argument . '%';
 
-						$out[0] .= sprintf( $opMap[$filter['op']], $mode,
+						$out[0] .= sprintf( $opMap[$op], $mode,
 											$filter['col'] );
 
 						if ( is_array( $out[1] ) )

--- a/database2.php
+++ b/database2.php
@@ -951,7 +951,7 @@ EOT
 	 */
 
 	protected function editRecord( $rowid, $readOnly, $duplicateOf = null,
-								   $rowACL = null )
+								   $rowACL = null, $retn = true )
 	{
 
 		$ioIndex  = $this->getIndex();
@@ -1293,14 +1293,14 @@ EOT
 		// compile form
 		$elements = array();
 
-		$elements[] = $this->renderField( true, null, null, array(), null, $readOnly, $rowACL );
+		$elements[] = $this->renderField( true, null, null, array(), null, $readOnly, $rowACL, $retn );
 
 		foreach ( $store as $column => $value )
 			$elements[] = $this->renderField( $rowid, $column, $value,
 											  $this->meta[$column],
-											  $errors[$column], $readOnly, $rowACL );
+											  $errors[$column], $readOnly, $rowACL, $retn );
 
-		$elements[] = $this->renderField( false, $nav, null, array(), null, $readOnly, $rowACL );
+		$elements[] = $this->renderField( false, $nav, null, array(), null, $readOnly, $rowACL, $retn );
 
 
 		if ( $readOnly && $rowid )
@@ -2080,9 +2080,21 @@ EOT
 
 		$trClass    = $this->options['wikistyle'] ? '' : ' class="data-list"';
 		$tableClass = $this->options['wikistyle'] ? ' class="inline"' : '';
+		$headerstyle = $this->options['hideheader'];
+		$detailview = $this->options['detailview'];
 
-
-		$table = <<<EOT
+		if ( !$detailview || $count > 1 ) {
+			if ( $headerstyle ) {
+				$table = <<<EOT
+   <table width="100%"$tableClass>
+     <tbody>
+     $rows
+     </tbody>
+   </table>
+EOT;
+			}
+			else {
+				$table = <<<EOT
    <table width="100%"$tableClass>
     <thead>
      <tr class="row0">
@@ -2099,7 +2111,7 @@ EOT
     </caption>
    </table>
 EOT;
-
+			}
 		if ( $expectInput || !$listAll )
 			$table     = <<<EOT
 <table class="database2"$width>
@@ -2141,6 +2153,10 @@ EOT;
  </tbody>
 </table>
 EOT;
+		}
+		else {
+			$this->editRecord( $rowid, true, null, null, false);
+		}
 
 		return $expectInput ? $this->wrapInForm( $table ) : $table;
 
@@ -2839,7 +2855,6 @@ EOT;
 		{
 
 			if ( !is_array( $session['search'] ) )
-			{
 
 				$session['search'] = array();
 
@@ -2847,7 +2862,6 @@ EOT;
 					// initialize filter using provided code
 					return ( $session['search'] = $this->parseFilterCode( $this->options['basefilter'] ) );
 
-			}
 
 
 			// parse filter input and transfer it to session
@@ -5718,7 +5732,7 @@ EOT
 	 * @return string HTML code representing single form field
 	 */
 
-	protected function renderField( $rowid, $column, $value, $def, $error, $readOnly, &$rowACL )
+	protected function renderField( $rowid, $column, $value, $def, $error, $readOnly, &$rowACL, $retn )
 	{
 
 		if ( $rowid === true )
@@ -5770,11 +5784,12 @@ EOT;
 					$name = $this->getLang( 'cmdreturn' );
 				}
 
-
-				$buttons[] = '<input type="submit" name="' .
+				if ( $retn ) {
+					$buttons[] = '<input type="submit" name="' .
 							 $this->varname( '____cancel' ) .
 							 '" value="' . ( $readOnly ? $name : ( $mode ? $this->getLang( 'cmdnosave' ) : $this->getLang( 'cmdcancel' ) ) ) .
 							 '" />';
+				}
 
 				if ( $mode )
 					$buttons[] = $mode;


### PR DESCRIPTION
Option 1: hideheader: hides header of table
Option 2: detailview: use the view of inspect directly as an option without address parameters (if only one record seleted, buttons are disabled)
Bugfix: basefilter did not accept syntax in uppercase like "LIKE" due to case sensitive field names in array
