### PR TITLE
Use <database> tag for compatibility sake

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -42,11 +42,11 @@ class syntax_plugin_database2 extends DokuWiki_Syntax_Plugin {
      * @param string $mode Parser mode
      */
     public function connectTo($mode) {
-        $this->Lexer->addEntryPattern("<database2.*?>(?=.*?</database2>)", $mode, 'plugin_database2');
+        $this->Lexer->addEntryPattern("<database.*?>(?=.*?</database>)", $mode, 'plugin_database2');
     }
 
     public function postConnect() {
-        $this->Lexer->addExitPattern('</database2>','plugin_database2');
+        $this->Lexer->addExitPattern('</database>','plugin_database2');
     }
 
     /**


### PR DESCRIPTION
Hi.

Thank you for keeping this great plugin running and up to date with current DokuWiki.

However, the change form `<database>` to `<database2>` introduced in commit [dd860181afdb47091e2a20639f48a6e70dea3bfe](https://github.com/igittigitt/dokuwiki-plugin-database2/commit/dd860181afdb47091e2a20639f48a6e70dea3bfe)  (or was it [c89678e704eab1a5411bc57dafe94811c0fdad7d](https://github.com/igittigitt/dokuwiki-plugin-database2/commit/c89678e704eab1a5411bc57dafe94811c0fdad7d)) simply breaks the existing pages.

On the other side, there is this idea of not conflicting with the [database plugin](https://www.dokuwiki.org/plugin:database). This plugin has not been maintained for almost 10 years, and was already incompatible with DW 2008-05-05. As of today, once installed it will simply break the entire wiki : all non cached page render as blank page, as well as the admin panel.  In fact, it cannot load because of syntax errors ! So it is questionable wether not conflicting with it matters.

Please consider going back to `<database>` for compatibility reasons.
