### PR TITLE
Fix warning about non-numeric value

### DIFF
--- a/database2.php
+++ b/database2.php
@@ -5895,7 +5895,7 @@ EOT;
 					{
 
 						$selected     = ( $index === $value ) ? ' selected="selected"' : '';
-						$selectedAny |= $selected;
+						$selectedAny |= !!$selected;
 
 						if ( $def['format'] == 'enum' )
 							$key = $index + 1;


### PR DESCRIPTION
Specifically, "**Warning**: A non-numeric value encountered in **/home/wiki/www/lib/plugins/database2/database2.php** on line **5898**" when adding or editing a record.